### PR TITLE
Adjust get() to bridge HTTP::Tiny and WWW::Mechanize APIs

### DIFF
--- a/lib/HTTP/Tiny/Mech.pm
+++ b/lib/HTTP/Tiny/Mech.pm
@@ -84,7 +84,7 @@ Interface should be the same as it is with L<HTTP::Tiny/get>.
 
 sub get {
   my ( $self, $uri, $opts ) = @_;
-  return $self->_unwrap_response( $self->mechua->get( $uri, $opts ) );
+  return $self->_unwrap_response( $self->mechua->get( $uri, ($opts? %$opts : ()) ) );
 }
 
 =head2 request


### PR DESCRIPTION
HTTP::Tiny get() API is ($self, $url, $opts) where $opts is a HashRef.

But then the request is passed to WWW::Mechanize get(), where the last
parameter is a list, not a HashRef.

This was giving me problems with Dist::Zilla. An example traceback:

```
Illegal field name '' at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/HTTP/Request/Common.pm line 115.
 at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/HTTP/Request/Common.pm line 116.
  HTTP::Request::Common::_simple_req(undef, undef) called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/HTTP/Request/Common.pm line 20
  HTTP::Request::Common::GET('http://api.metacpan.org/v0/file/_search?fields=distribution%2...', undef) called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/LWP/UserAgent.pm line 410
  LWP::UserAgent::get('WWW::Mechanize::Cached::GZip=HASH(0x35f6090)', 'http://api.metacpan.org/v0/file/_search?fields=distribution%2...', undef) called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/WWW/Mechanize.pm line 407
  == 2 ==> WWW::Mechanize::get('WWW::Mechanize::Cached::GZip=HASH(0x35f6090)', 'http://api.metacpan.org/v0/file/_search?fields=distribution%2...', undef) called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/HTTP/Tiny/Mech.pm line 53
  == 1 ==> HTTP::Tiny::Mech::get('HTTP::Tiny::Mech=HASH(0x35e1b70)', 'http://api.metacpan.org/v0/file/_search?fields=distribution%2...') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/MetaCPAN/API.pm line 59
  MetaCPAN::API::fetch('MetaCPAN::API=HASH(0x35121b0)', 'file/_search', 'q', 'module.name:"ExtUtils::MakeMaker" AND status:latest AND modul...', 'fields', 'distribution,release', 'size', 1) called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/Plugin/PrereqsClean.pm line 225
  Dist::Zilla::Plugin::PrereqsClean::_mcpan_module2distro('Dist::Zilla::Plugin::PrereqsClean=HASH(0x3127960)', 'ExtUtils::MakeMaker') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/Plugin/PrereqsClean.pm line 86
  Dist::Zilla::Plugin::PrereqsClean::register_prereqs('Dist::Zilla::Plugin::PrereqsClean=HASH(0x3127960)') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/Dist/Builder.pm line 270
  Dist::Zilla::Dist::Builder::build_in('Dist::Zilla::Dist::Builder=HASH(0xebf8b0)', 'Path::Class::Dir=HASH(0x30ba4e0)') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/Dist/Builder.pm line 315
  Dist::Zilla::Dist::Builder::ensure_built_in('Dist::Zilla::Dist::Builder=HASH(0xebf8b0)', 'Path::Class::Dir=HASH(0x30ba4e0)') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/Dist/Builder.pm line 504
  Dist::Zilla::Dist::Builder::ensure_built_in_tmpdir('Dist::Zilla::Dist::Builder=HASH(0xebf8b0)') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/Dist/Builder.pm line 547
  Dist::Zilla::Dist::Builder::test('Dist::Zilla::Dist::Builder=HASH(0xebf8b0)') called at /Users/melo/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Dist/Zilla/App/Command/test.pm line 28
```

The problem spots are marked == N ==>. 1 is the H::T::M::get() call and 2 is the W::M ::get() call, with a single undef argument, that will choke eventually upstream when undef => undef is tried as a header pair.
