### PR TITLE
Return decoded_content in _unwrap_response().

### DIFF
--- a/lib/HTTP/Tiny/Mech.pm
+++ b/lib/HTTP/Tiny/Mech.pm
@@ -89,7 +89,7 @@ sub _unwrap_response {
     reason  => $response->message,
     headers => $response->headers,
     success => $response->is_success,
-    content => $response->content,
+    content => $response->decoded_content,
   };
 }
 


### PR DESCRIPTION
I was using a plain WWW::Mechanize object today and I was getting the following error:

```
Couldn't decode '��QO�˒�l0��(�b�E0C���Ʊ��c�k;�D�vwk�a�0N7�3�F$ƥ�o����y�6iAҳf��6�kWŜ��7���r�TX��
                                                                                                  �⎽���└3
                                                                                                         ⎽�땿Ӆ��┴@└�▒��]�F��%V⎽(FQG4▒R?b����X�N◆�8d����ڨ��─:c%ڑ��eJ�±BJ±┴e�#B�
                                                                                                                                                                              ⎺^��≤@�Ѿ�W▮I≤��┘$\]����4�#≤�С#6��2�↓�Z�'Ƥ<��±Mߟ£��]�H:': └▒┌°⎺⎼└ed JSON ⎽├⎼☃┼±← ┼e☃├▒e⎼ ├▒±← ▒⎼⎼▒≤← ⎺b┘ec├← ┼┤└be⎼← ⎽├⎼☃┼± ⎺⎼ ▒├⎺└←
        ▒├ Me├▒CPAN::C┌☃e┼├::Re─┤e⎽├::├⎼≤ π↓↓↓£ (c▒▒⎼▒c├e⎼ ⎺°°⎽e├ ▮ (be°⎺⎼e "\│π1°£\│π°°°d£\│π8£\│π▮£↓↓↓") ▒├ /U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├/Re─┤e⎽├↓⎻└:113)
        ▒├ <e┴▒┌>(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/T⎼≤/T☃┼≤↓⎻└:81)
        ▒├ T⎼≤::T☃┼≤::├⎼≤(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/T⎼≤/T☃┼≤↓⎻└:72)
        ▒├ Me├▒CPAN::C┌☃e┼├::Re─┤e⎽├::_dec⎺de_⎼e⎽┤┌├(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├/Re─┤e⎽├↓⎻└:114)
        ▒├ Me├▒CPAN::C┌☃e┼├::Re─┤e⎽├::°e├c▒(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├/Re─┤e⎽├↓⎻└:62)
        ▒├ Me├▒CPAN::C┌☃e┼├::°e├c▒(<e┴▒┌>:12)
        ▒├ Me├▒CPAN::C┌☃e┼├::_±e├(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├↓⎻└:167)
        ▒├ Me├▒CPAN::C┌☃e┼├::_±e├_⎺⎼_⎽e▒⎼c▒(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├↓⎻└:2▮9)
        ▒├ Me├▒CPAN::C┌☃e┼├::▒┤├▒⎺⎼(/U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├↓⎻└:44)
        ▒├ └▒☃┼::(e│▒└⎻┌e⎽/└e├c⎻▒┼↑c┌☃e┼├↓⎻┌:19)
 ▒├ /U⎽e⎼⎽/⎺┌▒°/⎻e⎼┌5/┌☃b/⎻e⎼┌5/Me├▒CPAN/C┌☃e┼├/Re─┤e⎽├↓⎻└ ┌☃┼e 114↓
```

Returning decoded_content() fixes that for me.
